### PR TITLE
feat(docker): dockerised working setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:10
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# URL Shortener
+
+Start the API and DB using Docker:
+
+```
+docker-compose up
+```
+
+Now the API should be available on port `8080`:
+
+```
+curl localhost:8080/api/shorturl/1    # 200 - yay!
+curl localhost:8080/api/shorturl/1000 # 404
+curl localhost:8080/api/status        # 200 - status check
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+  api:
+    image: node:10
+    user: "node"
+    environment:
+      - PORT=8000
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_USER=postgres
+      - DB_NAME=postgres
+      - DB_PASSWORD=postgres
+    ports:
+      - "8000:8000"
+    expose:
+      - "8000"
+    volumes:
+      - ./:/home/node/app
+    working_dir: /home/node/app
+    command: "npm start"
+    depends_on:
+      - db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/status"]
+      interval: 10s
+      timeout: 1s
+      retries: 3
+
+  db:
+    image: postgres
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
-const express = require('express')
+const express = require("express");
 const app = express();
-const { Client } = require('pg')
-const PORT = 44444;
+const { Client } = require("pg");
+const PORT = process.env.PORT || 44444;
 // const parse = require('pg-connection-string').parse // Parser for
 
 // Use env file values for security
@@ -11,21 +11,30 @@ const client = new Client({
   database: process.env.DB_NAME,
   password: process.env.DB_PASSWORD,
   port: process.env.DB_PORT
-})
+});
 
-client.connect()
-  .then((() => console.log('connected to DB')))
-  .catch(e => console.error(e.stack))
+client
+  .connect()
+  .then(() => console.log("connected to DB"))
+  .catch(e => console.error(e.stack));
 
-app.get('/api/shorturl/:id', (req, res) => {
-  client.query(`SELECT * from urls;`)
-    .then(res => {
-      console.log(res.rows[0])
+app.get("/api/shorturl/:id", (req, res) => {
+  client
+    .query("SELECT * from urls where shorturl = $1", [req.param("id")])
+    .then(data => {
+      data.rows.length > 0 ? res.send(data.rows[0]) : res.sendStatus(404);
     })
-    .catch(e => console.error(e.stack))
-})
+    .catch(e => {
+      console.error(e.stack);
+      res.sendStatus(500);
+    });
+});
+
+app.get("/api/status", (req, res) => {
+  res.sendStatus(200);
+});
 
 // Constants
-const HOST = '0.0.0.0';
+const HOST = "0.0.0.0";
 
-app.listen(PORT, () => console.log(`Listening on PORT: ${PORT}`))
+app.listen(PORT, () => console.log(`Listening on PORT: ${PORT}`));

--- a/sql/01-schema.sql
+++ b/sql/01-schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE urls (
+ shorturl SERIAL PRIMARY KEY,
+ originalurl VARCHAR(253)
+);

--- a/sql/02-data.sql
+++ b/sql/02-data.sql
@@ -1,0 +1,1 @@
+INSERT INTO urls (shorturl, originalurl) VALUES (1, 'http://www.google.com');


### PR DESCRIPTION
* Add docker setup (standardise the runtime to avoid environment differences)
* Setup port to `8000` (much more standard) and used env vars as default
* Fixed the `/api/shorturl` endpoint to actually return a status, and query based on the parameter
* Added `/api/status` endpoint for the docker runtime to check when the API is up
* Added `.gitignore` to avoid an accidental commit of `node_modules` :)

Also, I use Prettier (you should too) and it formatted some stuff - sorry.